### PR TITLE
doctor appointments page with filters, today toggle, and sort

### DIFF
--- a/backend/src/TeleHealth.Api/Features/Doctors/GetSchedule/GetDoctorScheduleHandler.cs
+++ b/backend/src/TeleHealth.Api/Features/Doctors/GetSchedule/GetDoctorScheduleHandler.cs
@@ -20,7 +20,10 @@ public sealed class GetDoctorScheduleHandler(ApplicationDbContext db)
         var pageSize = Math.Clamp(query.PageSize, 1, MaxPageSize);
 
         var utcNow = SystemClock.Instance.GetCurrentInstant().InUtc();
-        var date = query.Date.HasValue ? LocalDate.FromDateOnly(query.Date.Value) : utcNow.Date;
+        var date = query.Date.HasValue
+            ? (LocalDate?)LocalDate.FromDateOnly(query.Date.Value)
+            : null;
+        var todayDate = utcNow.Date;
         var timeNow = utcNow.TimeOfDay;
 
         var doctor = await db
@@ -34,10 +37,11 @@ public sealed class GetDoctorScheduleHandler(ApplicationDbContext db)
 
         var doctorId = doctor.Id;
 
-        // Base query: this doctor's appointments for the requested date
-        var q = db
-            .Appointments.AsNoTracking()
-            .Where(a => a.DoctorId == doctorId && a.DoctorSchedule.Date == date);
+        // Base query: this doctor's appointments, optionally filtered by date
+        var q = db.Appointments.AsNoTracking().Where(a => a.DoctorId == doctorId);
+
+        if (date.HasValue)
+            q = q.Where(a => a.DoctorSchedule.Date == date.Value);
 
         if (query.Status is not null)
             q = q.Where(a => a.AppointmentStatus.Slug == query.Status);
@@ -55,23 +59,24 @@ public sealed class GetDoctorScheduleHandler(ApplicationDbContext db)
 
         var totalCount = await q.CountAsync(ct);
 
-        // Pending = booked but not yet started
+        // Pending = booked appointments on the queried date (or today if no date given)
+        var statsDate = date ?? todayDate;
         var pendingCount = await db
             .Appointments.AsNoTracking()
             .CountAsync(
                 a =>
                     a.DoctorId == doctorId
-                    && a.DoctorSchedule.Date == date
+                    && a.DoctorSchedule.Date == statsDate
                     && a.StatusId == StatusId.Appointment.Booked,
                 ct
             );
 
-        // Next appointment = soonest start time still in the future, not completed/cancelled
+        // Next appointment = soonest start time still in the future on statsDate
         var nextAppointmentTime = await db
             .Appointments.AsNoTracking()
             .Where(a =>
                 a.DoctorId == doctorId
-                && a.DoctorSchedule.Date == date
+                && a.DoctorSchedule.Date == statsDate
                 && a.DoctorSchedule.StartTime > timeNow
                 && (
                     a.StatusId == StatusId.Appointment.Booked
@@ -82,10 +87,8 @@ public sealed class GetDoctorScheduleHandler(ApplicationDbContext db)
             .Select(a => (LocalTime?)a.DoctorSchedule.StartTime)
             .FirstOrDefaultAsync(ct);
 
-        q =
-            query.SortOrder?.ToLowerInvariant() == "desc"
-                ? q.OrderByDescending(a => a.DoctorSchedule.StartTime)
-                : q.OrderBy(a => a.DoctorSchedule.StartTime);
+        // Date DESC (latest first), then time ASC (earliest slot first within each day)
+        q = q.OrderByDescending(a => a.DoctorSchedule.Date).ThenBy(a => a.DoctorSchedule.StartTime);
 
         var items = await q.Skip((page - 1) * pageSize)
             .Take(pageSize)

--- a/frontend/src/features/appointments/AppointmentDetailsPage.tsx
+++ b/frontend/src/features/appointments/AppointmentDetailsPage.tsx
@@ -42,7 +42,9 @@ export function AppointmentDetailsPage() {
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
-              <BreadcrumbLink render={<Link to="/appointments" />}>Appointments</BreadcrumbLink>
+              <BreadcrumbLink render={<Link to="/appointments" search={{ today: undefined }} />}>
+                Appointments
+              </BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>

--- a/frontend/src/features/appointments/AppointmentsPage.tsx
+++ b/frontend/src/features/appointments/AppointmentsPage.tsx
@@ -8,6 +8,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { useAuthStore } from "@/store/useAuthStore";
+import { DoctorAppointmentPage } from "./roles/DoctorAppointmentPage";
 import { ReceptionistApptPage } from "./roles/ReceptionistAppointment";
 
 export function AppointmentsPage() {
@@ -20,7 +21,7 @@ export function AppointmentsPage() {
       case "receptionist":
         return <ReceptionistApptPage />;
       case "doctor":
-        return "Do something";
+        return <DoctorAppointmentPage />;
       case "admin":
         return "Do something";
       case "lab-tech":

--- a/frontend/src/features/appointments/roles/DoctorAppointmentPage.tsx
+++ b/frontend/src/features/appointments/roles/DoctorAppointmentPage.tsx
@@ -1,0 +1,317 @@
+import { useNavigate } from "@tanstack/react-router";
+import { type ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { AnimatePresence, motion } from "framer-motion";
+import { CalendarDays, Search } from "lucide-react";
+import type { DoctorAppointmentDto } from "@/api/model/DoctorAppointmentDto";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatLocalDate, formatLocalTime } from "@/features/dashboard/roles/UseDoctorSchedule";
+import { type StatusFilter, UseDoctorAppointmentPage } from "./UseDoctorAppointmentPage";
+
+const ACCENT = "#0d9488";
+
+const STATUS_TABS: { label: string; value: StatusFilter }[] = [
+  { label: "All", value: "all" },
+  { label: "Booked", value: "booked" },
+  { label: "Cancelled", value: "cancelled" },
+  { label: "Completed", value: "completed" },
+];
+
+function ViewCell({ row }: { row: { original: DoctorAppointmentDto } }) {
+  const navigate = useNavigate();
+  const status = row.original.status ?? "";
+  const canView = status === "Booked" || status === "Completed";
+
+  if (!canView) return <span className="text-muted-foreground/40 text-xs">—</span>;
+
+  return (
+    <Button
+      size="sm"
+      className="h-7 px-3 text-xs bg-[#0d9488] text-white hover:bg-[#0b857a]"
+      onClick={() =>
+        navigate({ to: "/appointments/$id", params: { id: row.original.publicId ?? "" } })
+      }
+    >
+      View
+    </Button>
+  );
+}
+
+const columns: ColumnDef<DoctorAppointmentDto>[] = [
+  {
+    accessorKey: "date",
+    header: "Date",
+    cell: ({ row }) => (
+      <span className="text-foreground">{formatLocalDate(String(row.original.date ?? ""))}</span>
+    ),
+  },
+  {
+    accessorKey: "startTime",
+    header: "Time",
+    cell: ({ row }) => (
+      <span className="font-medium text-foreground">
+        {formatLocalTime(row.original.startTime)} – {formatLocalTime(row.original.endTime)}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "patientName",
+    header: "Patient",
+    cell: ({ getValue }) => <span className="font-medium">{(getValue() as string) ?? "—"}</span>,
+  },
+  {
+    accessorKey: "visitReason",
+    header: "Visit Reason",
+    cell: ({ getValue }) => (
+      <span className="text-muted-foreground text-sm line-clamp-1 max-w-52">
+        {(getValue() as string) ?? "—"}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const color = row.original.statusColorCode;
+      return (
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+          style={{
+            borderColor: color ?? undefined,
+            color: color ?? undefined,
+            backgroundColor: color ? `${color}12` : undefined,
+          }}
+        >
+          <span
+            className="w-1.5 h-1.5 rounded-full shrink-0"
+            style={{ background: color ?? undefined }}
+          />
+          {row.original.status ?? "—"}
+        </span>
+      );
+    },
+  },
+  {
+    id: "action",
+    header: "Action",
+    cell: ({ row }) => <ViewCell row={row} />,
+  },
+];
+
+export function DoctorAppointmentPage() {
+  const {
+    items,
+    totalCount,
+    totalPages,
+    page,
+    search,
+    statusFilter,
+    todayOnly,
+    isLoading,
+    isError,
+    setPage,
+    handleSearchChange,
+    handleStatusChange,
+    handleTodayToggle,
+  } = UseDoctorAppointmentPage();
+
+  const table = useReactTable({
+    data: items,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    rowCount: totalCount,
+  });
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, ease: "easeOut" }}
+    >
+      <div className="relative overflow-hidden rounded-xl border border-border bg-card">
+        <div className="absolute top-0 inset-x-0 h-0.75" style={{ background: ACCENT }} />
+
+        {/* Header */}
+        <div className="flex items-end justify-between px-6 pt-6 pb-4">
+          <div>
+            <p
+              className="text-[10px] tracking-[0.22em] uppercase font-semibold mb-1"
+              style={{ color: ACCENT }}
+            >
+              Appointments
+            </p>
+            <h1 className="text-2xl font-semibold tracking-tight leading-none">
+              {todayOnly ? "Today's Schedule" : "All Appointments"}
+            </h1>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {!isLoading && !isError && (
+              <span className="font-mono text-xs text-muted-foreground border border-border rounded-full px-3 py-1">
+                {totalCount} {totalCount === 1 ? "appointment" : "appointments"}
+              </span>
+            )}
+            <Button
+              size="sm"
+              variant={todayOnly ? "default" : "outline"}
+              className={
+                todayOnly
+                  ? "bg-[#0d9488] text-white hover:bg-[#0b857a] h-8 px-3 text-xs"
+                  : "h-8 px-3 text-xs border-border text-muted-foreground hover:text-foreground"
+              }
+              onClick={handleTodayToggle}
+            >
+              <CalendarDays className="size-3.5 mr-1.5" />
+              Today's Schedule
+            </Button>
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Filters */}
+        <div className="flex items-center justify-between px-6 py-4 gap-4">
+          {/* Status tabs */}
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-muted/30 p-1">
+            {STATUS_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                onClick={() => handleStatusChange(tab.value)}
+                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
+                  statusFilter === tab.value
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Search */}
+          <div className="relative w-64">
+            <Search className="absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+            <Input
+              placeholder="Search patient or reason..."
+              value={search}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="pl-9 h-9 text-sm"
+            />
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Table */}
+        <div className="px-6 py-4">
+          {isError ? (
+            <div className="flex items-center justify-center h-48">
+              <p className="text-sm text-destructive">Failed to load appointments.</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow
+                    key={headerGroup.id}
+                    className="bg-foreground hover:bg-foreground border-b border-foreground/20"
+                  >
+                    {headerGroup.headers.map((header) => (
+                      <TableHead
+                        key={header.id}
+                        className="text-background/70 font-semibold px-4 py-3 text-[11px] tracking-[0.15em] uppercase"
+                      >
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                <AnimatePresence mode="wait">
+                  {isLoading ? (
+                    ["sk-1", "sk-2", "sk-3", "sk-4", "sk-5"].map((key) => (
+                      <TableRow key={key}>
+                        {["date", "time", "patient", "reason", "status", "action"].map((col) => (
+                          <TableCell key={`${key}-${col}`} className="px-4 py-3">
+                            <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    ))
+                  ) : table.getRowModel().rows.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={columns.length} className="h-40 text-center">
+                        <p className="text-sm text-muted-foreground">No appointments found.</p>
+                        <p className="text-xs text-muted-foreground/60 mt-1">
+                          Try adjusting your search or filter.
+                        </p>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    table.getRowModel().rows.map((row) => (
+                      <motion.tr
+                        key={row.id}
+                        initial={{ opacity: 0, y: 4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0 }}
+                        className="border-b border-border transition-colors last:border-0 hover:bg-muted/50"
+                      >
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell key={cell.id} className="px-4 py-3 text-sm">
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </TableCell>
+                        ))}
+                      </motion.tr>
+                    ))
+                  )}
+                </AnimatePresence>
+              </TableBody>
+            </Table>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <>
+            <Separator />
+            <div className="flex items-center justify-between px-6 py-3 text-sm text-muted-foreground">
+              <span>
+                Page {page} of {totalPages} &nbsp;·&nbsp; {totalCount} total
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={page <= 1}
+                  onClick={() => setPage(page - 1)}
+                >
+                  Previous
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage(page + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/features/appointments/roles/UseDoctorAppointmentPage.tsx
+++ b/frontend/src/features/appointments/roles/UseDoctorAppointmentPage.tsx
@@ -1,0 +1,66 @@
+import { useSearch } from "@tanstack/react-router";
+import { useState } from "react";
+import { useGetDoctorSchedule } from "@/api/generated/doctors/doctors";
+
+const PAGE_SIZE = 15;
+
+export type StatusFilter = "all" | "booked" | "cancelled" | "completed";
+
+function getTodayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function UseDoctorAppointmentPage() {
+  const { today } = useSearch({ from: "/_protected/appointments_" });
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [todayOnly, setTodayOnly] = useState(today ?? false);
+
+  const statusSlug = statusFilter === "all" ? undefined : statusFilter;
+
+  const { data, isLoading, isError } = useGetDoctorSchedule({
+    Date: todayOnly ? getTodayStr() : undefined,
+    Status: statusSlug,
+    Search: search.trim() || undefined,
+    Page: page,
+    PageSize: PAGE_SIZE,
+  });
+
+  const schedule = data?.status === 200 ? data.data : null;
+  const totalCount = Number(schedule?.totalCount ?? 0);
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+  function handleSearchChange(value: string) {
+    setSearch(value);
+    setPage(1);
+  }
+
+  function handleStatusChange(value: StatusFilter) {
+    setStatusFilter(value);
+    setPage(1);
+  }
+
+  function handleTodayToggle() {
+    setTodayOnly((prev) => !prev);
+    setPage(1);
+  }
+
+  return {
+    items: schedule?.items ?? [],
+    totalCount,
+    totalPages,
+    page,
+    pageSize: PAGE_SIZE,
+    search,
+    statusFilter,
+    todayOnly,
+    isLoading,
+    isError,
+    setPage,
+    handleSearchChange,
+    handleStatusChange,
+    handleTodayToggle,
+  };
+}

--- a/frontend/src/features/dashboard/roles/DoctorDashboard.tsx
+++ b/frontend/src/features/dashboard/roles/DoctorDashboard.tsx
@@ -1,10 +1,12 @@
-import { ClipboardPlus, Clock, Stethoscope, Users } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import { ClipboardPlus, Clock, List, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DoctorScheduleTable } from "./DoctorScheduleTable";
 import { formatLocalTime, UseDoctorSchedule } from "./UseDoctorSchedule";
 
 export function DoctorDashboard() {
+  const navigate = useNavigate();
   const { schedule, isLoading, page, setPage, search, setSearch, pageSize } = UseDoctorSchedule();
 
   const totalCount = Number(schedule?.totalCount ?? 0);
@@ -77,8 +79,12 @@ export function DoctorDashboard() {
               Click a patient to view medical history and add notes.
             </p>
           </div>
-          <Button size="sm">
-            <Stethoscope className="mr-2 size-4" /> View Full Calendar
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => navigate({ to: "/appointments", search: { today: true } })}
+          >
+            <List className="mr-2 size-4" /> View Full List
           </Button>
         </div>
         <div className="p-6">
@@ -89,6 +95,7 @@ export function DoctorDashboard() {
             pageSize={pageSize}
             search={search}
             isLoading={isLoading}
+            hidePagination
             onPageChange={setPage}
             onSearchChange={setSearch}
           />

--- a/frontend/src/features/dashboard/roles/DoctorScheduleTable.tsx
+++ b/frontend/src/features/dashboard/roles/DoctorScheduleTable.tsx
@@ -23,6 +23,7 @@ type Props = {
   pageSize: number;
   search: string;
   isLoading: boolean;
+  hidePagination?: boolean;
   onPageChange: (page: number) => void;
   onSearchChange: (search: string) => void;
 };
@@ -105,6 +106,7 @@ export function DoctorScheduleTable({
   pageSize,
   search,
   isLoading,
+  hidePagination = false,
   onPageChange,
   onSearchChange,
 }: Props) {
@@ -190,7 +192,7 @@ export function DoctorScheduleTable({
       </Table>
 
       {/* Pagination */}
-      {totalPages > 1 && (
+      {!hidePagination && totalPages > 1 && (
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span>
             Page {page} of {totalPages}

--- a/frontend/src/features/dashboard/roles/UseDoctorSchedule.tsx
+++ b/frontend/src/features/dashboard/roles/UseDoctorSchedule.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useGetDoctorSchedule } from "@/api/generated/doctors/doctors";
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 5;
 
 // LocalTime from backend is "HH:mm:ss" — convert to "10:30 AM"
 export function formatLocalTime(time?: string): string {
@@ -34,11 +34,17 @@ export function formatLocalDate(date?: string): string {
   return `${Number.parseInt(d, 10)} ${months[Number.parseInt(m, 10) - 1]} ${y}`;
 }
 
+function getTodayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
 export function UseDoctorSchedule() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
 
   const { data, isLoading, isError } = useGetDoctorSchedule({
+    Date: getTodayStr(),
     Page: page,
     PageSize: PAGE_SIZE,
     Search: search.trim() || undefined,

--- a/frontend/src/routes/_protected/appointments_.tsx
+++ b/frontend/src/routes/_protected/appointments_.tsx
@@ -3,5 +3,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { AppointmentsPage } from "@/features/appointments/AppointmentsPage";
 
 export const Route = createFileRoute("/_protected/appointments_")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    today: search.today === "true" || search.today === true || undefined,
+  }),
   component: AppointmentsPage,
 });


### PR DESCRIPTION
Add full appointments page for the doctor role with status filter tabs (All / Booked / Cancelled / Completed), search, and server-side pagination.

- Dashboard schedule capped at 5 rows; "View Full Calendar" renamed to "View Full List" — navigates to /appointments?today=true to pre-activate today filter; pagination hidden on dashboard
- Appointments page pre-activates Today's Schedule when today=true is in the URL search param
- Backend sort changed to date DESC then time ASC for all schedule queries
- Backend date filter made truly optional — omitting Date returns all appointments across all dates; dashboard now passes today's date explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added doctor appointments list view with search, status filtering, and "today only" toggle.
  * Added dashboard link to view complete appointments list.

* **Improvements**
  * Enhanced appointment scheduling logic for better date filtering behavior.
  * Updated navigation and breadcrumb handling in appointments section.
  * Improved sorting of appointments by date and time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->